### PR TITLE
Skip rust forks for now.

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -16,7 +16,12 @@ GH_API_HOST = "api.github.com"
 GH_API_REPOS = "/users/softdevteam/repos"
 
 # If you want to skip any soft-dev repos, you can add them here.
-SD_SKIP_REPOS = []
+SD_SKIP_REPOS = [
+    # Skipping rustc forks for now, as at the time of writing upstream rust
+    # (and thus our forks) always have vulns which are out of our control. Once
+    # `cargo audit` passes on upstream rust, we can reconsider these.
+    "rustcgc", "ykrustc",
+]
 
 
 def get_sd_rust_repos(token_file):


### PR DESCRIPTION
Every Monday morning I get an email about security vulnerabilities in our rustc forks because upstream does not (and has not since `cargo audit` was born) passed audits. We inherit upstream's audit failures in our rustc forks.

Because I get an email every week about this, it has become very easy to ignore these emails.

Let's skip rust forks for now. It's more important that we notice vulnerabilities in our libraries distributed on crates.io.