### PR TITLE
Filtering

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -42,9 +42,6 @@ def get_sd_rust_repos(token_file):
 
 
 def install_cargo_audit():
-    os.environ["RUSTUP_HOME"] = RUSTUP_HOME
-    os.environ["CARGO_HOME"] = CARGO_HOME
-
     check_call(["curl", "--proto", "=https", "--tlsv1.2", "-sSf",
                 "https://sh.rustup.rs", "-o", "rustup.sh"])
     check_call(["sh", "rustup.sh", "--no-modify-path", "-y"])
@@ -116,6 +113,9 @@ if __name__ == "__main__":
     except IndexError:
         print("usage: audit.py <token-file>")
         sys.exit(1)
+
+    os.environ["RUSTUP_HOME"] = RUSTUP_HOME
+    os.environ["CARGO_HOME"] = CARGO_HOME
 
     if not os.path.exists(".cargo"):
         install_cargo_audit()


### PR DESCRIPTION
For a while now we've had a security "warning" on the snare repo. That meant that I got an audit failure email every week and eventually it conditioned me into not reading the email.

This change allows us to skip specific RUSTSEC ids on a per-repo and per-package basis, but only for a limited period of time. The idea being that we can silence a warning for a while, but we shouldn't "skip and forget". Rather we re-evaluate skipped security warnings every so often in case circumstances have changed. For example, maybe a new workaround is available.

There are two kinds of security problem that `cargo audit` detects: "warnings" and "vulnerabilities". This PR only allows skipping of "warnings". When the need to skip a "vulnerability" arises, we can add that (the JSON for that class of error is a different shape).

Looks good?