### PR TITLE
Extend snare skip

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -30,7 +30,7 @@ SD_SKIP_REPOS = [
 # Security warnings to skip.
 # (repo-name, package, rustsec-id) -> expiry-date
 SKIP_WARNINGS = {
-    ("snare", "net2", "RUSTSEC-2020-0016"): date(2020, 10, 24),
+    ("snare", "net2", "RUSTSEC-2020-0016"): date(2021, 04, 02),
 }
 
 # XXX Implement skipping for vulnerabilities as needed.

--- a/audit.py
+++ b/audit.py
@@ -125,7 +125,7 @@ def process_json(repo_name, js):
             else:
                 del SKIP_WARNINGS[tup]
                 if expiry <= date.today():
-                    print(f"Note: skip for {adv['package']}/{adv['id']}"
+                    print(f"Note: skip for {adv['package']}/{adv['id']} "
                           "has expired.")
                     ret = False
                 else:


### PR DESCRIPTION
Do we still need the workaround for this:
```
Note: skip for net2/RUSTSEC-2020-0016has expired.
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 144 security advisories (from /home/buildbot-worker3/worker3/audit-builder/build/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (132 crate dependencies)
Crate:         net2
Version:       0.2.35
Warning:       unmaintained
Title:         `net2` crate has been deprecated; use `socket2` instead
Date:          2020-05-01
ID:            RUSTSEC-2020-0016
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0016
Dependency tree: 
net2 0.2.35
├── miow 0.2.1
│   └── mio 0.6.22
│       ├── tokio 0.2.22
│       │   ├── tokio-util 0.3.1
│       │   │   └── h2 0.2.7
│       │   │       └── hyper 0.13.8
│       │   │           └── snare 0.4.0
│       │   ├── snare 0.4.0
│       │   ├── hyper 0.13.8
│       │   └── h2 0.2.7
│       ├── mio-uds 0.6.8
│       │   └── tokio 0.2.22
│       └── mio-named-pipes 0.1.7
│           └── tokio 0.2.22
└── mio 0.6.22
```

If so, we need to extend the expiry date on the skip (second commit).