### PR TITLE
Fix leading zeros.

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -30,7 +30,7 @@ SD_SKIP_REPOS = [
 # Security warnings to skip.
 # (repo-name, package, rustsec-id) -> expiry-date
 SKIP_WARNINGS = {
-    ("snare", "net2", "RUSTSEC-2020-0016"): date(2021, 04, 02),
+    ("snare", "net2", "RUSTSEC-2020-0016"): date(2021, 4, 2),
 }
 
 # XXX Implement skipping for vulnerabilities as needed.


### PR DESCRIPTION
The audit checker didn't run properly this week due to:
```
  File "audit.py", line 33
    ("snare", "net2", "RUSTSEC-2020-0016"): date(2021, 04, 02),
                                                        ^
SyntaxError: invalid token
```

Looks like I didn't test the change properly. My bad.

This fixes it.