### PR TITLE
Extend expiry date on RUSTSEC-2020-0016 skip.

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -29,9 +29,8 @@ SD_SKIP_REPOS = [
 
 # Security warnings to skip.
 # (repo-name, package, rustsec-id) -> expiry-date
-SKIP_WARNINGS = {
-    ("snare", "net2", "RUSTSEC-2020-0016"): date(2021, 4, 2),
-}
+# Expiry date is `a datetime.date`.
+SKIP_WARNINGS = {}
 
 CUSTOM_AUDIT_DIRS = {
     "yk": [".", "internal_ws"],


### PR DESCRIPTION
This skip hasn't actually expired, but it will soon. It was only displayed in recent audits because another (unskipped) advisory was present.