### PR TITLE
Fix a crash regarding the advisory field.

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -133,7 +133,11 @@ def process_json(repo_name, js):
     for kind in js["warnings"].values():
         for warn in kind:
             adv = warn["advisory"]
-            tup = repo_name, adv["package"], adv["id"]
+            if adv is not None:
+                tup = repo_name, adv["package"], adv["id"]
+            else:
+                # If the advisory field is None use dummy info.
+                tup = repo_name, None, None
             try:
                 expiry = SKIP_WARNINGS[tup]
             except KeyError:


### PR DESCRIPTION
The audit crashed like this:
```
Traceback (most recent call last):
  File "audit.py", line 177, in <module>
    res = audit(r.name, r.clone_url)
  File "audit.py", line 119, in audit
    if not process_json(name, js):
  File "audit.py", line 136, in process_json
    tup = repo_name, adv["package"], adv["id"]
TypeError: 'NoneType' object is not subscriptable
```

The advisory field may be `None` which makes unpacking it invalid. In such a case,
just use dummy advisory info.