### PR TITLE
Vuln skipping

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -34,6 +34,9 @@ SKIP_REPOS = [
 # Security advisories to skip.
 # (repo-name, problem-package, rustsec-id) -> expiry-date
 # Expiry date is `a datetime.date`, e.g. `date(2021, 12, 2)`.
+#
+# XXX the keys of this map should also contain the account that owns the repo,
+# in case different accounts contain a repo by the same name.
 SKIP_ADVISORIES = {
     ("yksom", "chrono", "RUSTSEC-2020-0159"): date(2021, 12, 1),
     ("yksom", "time", "RUSTSEC-2020-0071"): date(2021, 12, 1),


### PR DESCRIPTION
This all started when I wanted to skip the advisories reported on yksom.

With `cargo audit`, advisories are categorised as either "warnings" or "vulnerabilities". We only had the ability to skip the former. This PR implements the ability to skip the latter too.

See individual commits.