### PR TITLE
Skip ykllvm in the audit.

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -28,6 +28,8 @@ SKIP_REPOS = [
     ("softdevteam", "ykrustc"),
     ("softdevteam", "rustgc"),
     ("softdevteam", "alloy"),
+    # ykllvm contains rust files and thus gets categorised as a rust repo.
+    ("ykjit", "ykllvm"),
     # unmaintained repos.
     ("softdevteam", "k2"),
     ("softdevteam", "error_recovery_experiment"),


### PR DESCRIPTION
Github has recently started classifying this repo as "containing rust", which is technically true: there are 4 rust files :)