### PR TITLE
Skip `alloy_hashbrown`

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -30,6 +30,7 @@ SKIP_REPOS = [
     ("softdevteam", "rustgc_paper"),
     ("softdevteam", "rustgc_paper_experiment"),
     ("softdevteam", "alloy"),
+    ("softdevteam", "alloy_hashbrown"),
     # ykllvm contains rust files and thus gets categorised as a rust repo.
     ("ykjit", "ykllvm"),
     # unmaintained repos.


### PR DESCRIPTION
This repo is a dependency for `alloy` (a fork of rustc) which must be pinned to a specific version. We also already skip `alloy` anyway.